### PR TITLE
patch pom.xml to avoid platform specitic encodings used for plugin metadata

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,6 +10,7 @@
     <packaging>atlassian-plugin</packaging>
 
     <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <jira.version>5.0.1</jira.version>
         <jira.data.version>5.0.1</jira.data.version>
     </properties>


### PR DESCRIPTION
Hi - I patched the pom for the following warning when building with the Atlassian plugin SDK on osx for deployment on a Centos system:

`% atlas-mvn package
..
[INFO] [resources:resources]
[WARNING] Using platform encoding (MacRoman actually) to copy filtered resources, i.e. build is platform dependent!
[INFO] Copying 17 resources`

thanks for keeping this repository up !  Saved me some headaches when upgrading from Jira 4.3 to 5.2
