### PR TITLE
Use @HtmlSafe annotation for Jira 6.1 escaping problem solve, update jgit version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
         <dependency>
             <groupId>org.eclipse.jgit</groupId>
             <artifactId>org.eclipse.jgit</artifactId>
-            <version>0.10.1</version>
+            <version>3.3.1.201403241930-r</version>
         </dependency>
         <dependency>
             <groupId>com.jcraft</groupId>
@@ -65,6 +65,12 @@
             <version>3.2.0</version>
             <scope>provided</scope>
         </dependency>
+		<dependency>
+			<groupId>com.atlassian.velocity.htmlsafe</groupId>
+			<artifactId>velocity-htmlsafe</artifactId>
+			<version>1.2.1-m2</version>
+			<scope>provided</scope>
+		</dependency>
 <!--
         <dependency>
             <groupId>opensymphony</groupId>

--- a/src/main/java/RepoTest.java
+++ b/src/main/java/RepoTest.java
@@ -18,7 +18,7 @@ public class RepoTest {
         }
 
         Repository repository = builder.build();
-        System.out.println(repository.getObjectsDirectory().exists());
+        System.out.println(repository.getObjectDatabase().exists());
 
         repository.scanForRepoChanges();
         for(Map.Entry<String, Ref> pair : repository.getAllRefs().entrySet()) {

--- a/src/main/java/com/xiplink/jira/git/GitManagerImpl.java
+++ b/src/main/java/com/xiplink/jira/git/GitManagerImpl.java
@@ -344,7 +344,7 @@ public class GitManagerImpl implements GitManager {
             return;
         }
 
-        if (!repository.getObjectsDirectory().exists()) {
+        if (!repository.getObjectDatabase().exists()) {
             log.error("Connection to git repository " + getRoot() + " failed: Invalid repository");
             // We don't want to throw an exception here because then the system
             // won't start if the repo is down or there is something wrong

--- a/src/main/java/com/xiplink/jira/git/issuetabpanels/changes/GitRevisionAction.java
+++ b/src/main/java/com/xiplink/jira/git/issuetabpanels/changes/GitRevisionAction.java
@@ -6,6 +6,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
+import com.atlassian.velocity.htmlsafe.HtmlSafe;
 import org.apache.commons.lang.StringUtils;
 import org.eclipse.jgit.diff.DiffEntry.ChangeType;
 import org.eclipse.jgit.revwalk.RevCommit;
@@ -93,6 +94,7 @@ public class GitRevisionAction extends AbstractIssueAction {
         return multipleGitRepositoryManager.getRepository(repoId).getFileDiffs(revision.getId().name());
     }
 
+	@HtmlSafe
     public String getLinkedLogMessageHtml() {
         // Name ends in Html to avoid HTML escaping
         // https://developer.atlassian.com/display/JIRADEV/Velocity+Templates


### PR DESCRIPTION
Hello.

According to https://developer.atlassian.com/display/CONFDEV/Enabling+XSS+Protection+in+Plugins Html method suffix should solve problem HTML escaping in velocity templates, but it does not work for v6.1 for some reasons. Fix it by add dependency to velocity-htmlsafe and use @HtmlSafe annotation.

Also refresh jgit version and minor changes for compatibility.
