### PR TITLE
Add support for GitBlit

### DIFF
--- a/src/main/java/com/xiplink/jira/git/linkrenderer/LinkFormatRenderer.java
+++ b/src/main/java/com/xiplink/jira/git/linkrenderer/LinkFormatRenderer.java
@@ -8,6 +8,8 @@ import com.xiplink.jira.git.FileDiff;
 import com.xiplink.jira.git.GitManager;
 import com.xiplink.jira.git.ViewLinkFormat;
 
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
 import java.util.Map;
 import org.apache.commons.lang.StringUtils;
 import org.eclipse.jgit.lib.ObjectId;
@@ -73,6 +75,12 @@ public class LinkFormatRenderer implements GitLinkRenderer {
                 "${path}", path.getPath(),
                 "${parent}", revision.getParent(0).getId().name()
         );
+
+        try {
+            subst.put("${encpath}", URLEncoder.encode(path.getPath(),"UTF-8").replace("+", "%20"));
+        } catch (UnsupportedEncodingException e) {
+            assert false;
+        }
 
         ObjectId[] blobs = path.getBlobs();
         if (blobs.length == 1) {

--- a/src/main/resources/gitweblinktypes.properties
+++ b/src/main/resources/gitweblinktypes.properties
@@ -1,4 +1,4 @@
-types=cgit fisheye github gitorius gitweb
+types=cgit fisheye github gitorius gitweb gitblit
 
 #---------------------------------
 # gitweb
@@ -69,3 +69,14 @@ rhodecode.changeset=https://<your_rhode_code_url>/<your_repo_name>/changeset/${r
 rhodecode.file.added=https://<your_rhode_code_url>/<your_repo_name>/files/${rev}/${path}
 rhodecode.file.modified=https://<your_rhode_code_url>/<your_repo_name>/diff/${path}?diff2=${rev}&diff1=${parent}&fulldiff=1&diff=diff
 rhodecode.file.deleted=https://<your_rhode_code_url>/<your_repo_name>/diff/${path}?diff2=${rev}&diff1=${parent}&fulldiff=1&diff=diff
+
+#---------------------------------
+# gitblit
+#---------------------------------
+gitblit.name=GitBlit
+gitblit.view=
+gitblit.changeset=${origin}/commitdiff/<project>/${rev}
+gitblit.file.added=${origin}/blob/<project>/${rev}/${encpath} 
+gitblit.file.modified=${origin}/blobdiff/<project>/${rev}/${encpath} 
+gitblit.file.deleted=${origin}/history/<project>/${rev}/${encpath}
+


### PR DESCRIPTION
Add GitBlit template, add a special "encoded path" placeholder that works with the peculiar way GitBlit handles paths in URLs
